### PR TITLE
Fix email case handling

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -230,12 +230,8 @@ async fn _sso_login(data: ConnectData, user_uuid: &mut Option<String>, conn: &mu
             if user.email != user_infos.email {
                 if CONFIG.mail_enabled() {
                     mail::send_sso_change_email(&user_infos.email).await?;
-                } else {
-                    info!(
-                        "User {} email changed in SSO provider from {} to {}",
-                        user.uuid, user.email, user_infos.email
-                    );
                 }
+                info!("User {} email changed in SSO provider from {} to {}", user.uuid, user.email, user_infos.email);
             }
             (user, device, new_device, twofactor_token, sso_user)
         }

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -227,7 +227,7 @@ async fn _sso_login(data: ConnectData, user_uuid: &mut Option<String>, conn: &mu
             (user, device, new_device, twofactor_token, sso_user)
         }
         Some((user, device, new_device, twofactor_token, sso_user)) => {
-            if user.email != user_infos.email {
+            if user.email.to_lowercase() != user_infos.email.to_lowercase() {
                 if CONFIG.mail_enabled() {
                     mail::send_sso_change_email(&user_infos.email).await?;
                 }


### PR DESCRIPTION
When updating an internal test server to your latest version, I noticed that all users where getting "your email has changed" messages. This PR does two things:

- Changed emails are always logged, regardless if sending mails is enabled
- Comparison of email addresses are performed case-insensitive
  This matches what [user::find_by_mail does](https://github.com/dani-garcia/vaultwarden/blob/2d98aa304501b0f710d3a97ec854acdfc115228f/src/db/models/user.rs#L367) and prevents a situation the user can't resolve ("email changed", but trying to change the email results in "email already in use").

Thanks!